### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bluebird": "^3.3.5",
     "body-parser": "~1.15.0",
     "debug": "~2.2.0",
-    "express": "~4.13.4",
+    "express": "~4.14.0",
     "express-x-hub": "^1.0.3",
     "habitica": "^3.0.0",
     "lodash": "^4.11.1",


### PR DESCRIPTION
Habitica-Webhooks is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:negotiator:20160616). 

Vulnerable module: `negotiator`
Introduced through: ` express`

This PR fixes the ReDOS vulnerability by upgrading `express` to version 4.14.0

Check out the [Snyk test report](https://snyk.io/test/github/HabitRPG/Habitica-Webhooks) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
* get alerts if newly disclosed vulnerabilities affect this repo in the future. 
* generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team